### PR TITLE
deduplicate all the of the eapol based tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: setup copy-certs
 	$(MAKE) clean-certs
 
 test: build
-	docker-compose run govwifi-test
+	docker-compose run --rm govwifi-test
 
 copy-certs:
 	cp -r "test-certs" "acceptance_tests/.certs"

--- a/acceptance_tests/spec/gov_wifi_certs_spec.rb
+++ b/acceptance_tests/spec/gov_wifi_certs_spec.rb
@@ -4,8 +4,7 @@ require 'spec_helper.rb'
 
 describe 'GovWifi Certificate Authentication' do
   context 'With valid eap-tls' do
-    let(:configuration) { 'eap-tls-accept.conf' }
-    it_behaves_like 'a valid auth'
+    it_behaves_like 'a valid auth', configuration='eap-tls-accept.conf'
     it 'logs the certificate name' do
       eapol_test_command
       expect(db[:sessions].first[:cert_name]).to eq("Example user")
@@ -13,7 +12,6 @@ describe 'GovWifi Certificate Authentication' do
   end
 
   context 'with invalid eap-tls' do
-    let(:configuration) { 'eap-tls-reject.conf' }
-    it_behaves_like 'an invalid auth'
+    it_behaves_like 'an invalid auth', configuration='eap-tls-reject.conf'
   end
 end

--- a/acceptance_tests/spec/gov_wifi_certs_spec.rb
+++ b/acceptance_tests/spec/gov_wifi_certs_spec.rb
@@ -1,71 +1,19 @@
 require 'socket'
 require 'sequel'
+require 'spec_helper.rb'
 
 describe 'GovWifi Certificate Authentication' do
-  let(:db) do
-    Sequel.connect(
-      adapter: 'mysql2',
-      host: ENV.fetch('DB_HOSTNAME'),
-      database: ENV.fetch('DB_NAME'),
-      user: ENV.fetch('DB_USER'),
-      password: ENV.fetch('DB_PASS')
-    )
-  end
-
-  let(:frontend_container_ip) do
-    TCPSocket.gethostbyname(ENV.fetch('FRONTEND_CONTAINER')).last
-  end
-
-  let(:radius_key) { ENV.fetch('RADIUS_KEY') }
-
-  let(:eapol_test_command) do
-    `eapol_test -t5 -c ./spec/support/#{configuration} -a #{frontend_container_ip} -s #{radius_key}`
-  end
-
-  let(:result) { eapol_test_command.split("\n").last }
-
-  context 'With valid credentials' do
+  context 'With valid eap-tls' do
     let(:configuration) { 'eap-tls-accept.conf' }
-
-    it 'Authenticates successfully' do
-      expect(result).to match('SUCCESS')
-    end
-
-    context 'Logging' do
-      before do
-        db[:sessions].truncate
-      end
-
-      it 'logs the authentication' do
-        eapol_test_command
-        expect(db[:sessions].order(:id).last).to_not be_nil
-      end
-
-      it 'logs one session' do
-        eapol_test_command
-        expect(db[:sessions].count).to eq(1)
-      end
-
-      it 'logs the certificate name' do
-        eapol_test_command
-        expect(db[:sessions].first[:cert_name]).to eq("Example user")
-      end
-    end
-
-    context 'With an invalid shared secret' do
-      let(:radius_key) { 'somerandomkey' }
-
-      it 'Rejects the authentication request' do
-        expect(result).to eq('FAILURE')
-      end
+    it_behaves_like 'a valid auth'
+    it 'logs the certificate name' do
+      eapol_test_command
+      expect(db[:sessions].first[:cert_name]).to eq("Example user")
     end
   end
 
-  context 'With invalid credentials' do
+  context 'with invalid eap-tls' do
     let(:configuration) { 'eap-tls-reject.conf' }
-
-    it 'Authenticates successfully' do
-      expect(result).to eq('FAILURE')
-    end
+    it_behaves_like 'an invalid auth'
   end
 end

--- a/acceptance_tests/spec/gov_wifi_certs_spec.rb
+++ b/acceptance_tests/spec/gov_wifi_certs_spec.rb
@@ -1,5 +1,3 @@
-require 'socket'
-require 'sequel'
 require 'spec_helper.rb'
 
 describe 'GovWifi Certificate Authentication' do

--- a/acceptance_tests/spec/gov_wifi_certs_spec.rb
+++ b/acceptance_tests/spec/gov_wifi_certs_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper.rb'
 
 describe 'GovWifi Certificate Authentication' do
   context 'With valid eap-tls' do
-    it_behaves_like 'a valid auth', configuration='eap-tls-accept.conf'
-    it 'logs the certificate name' do
-      eapol_test_command
-      expect(db[:sessions].first[:cert_name]).to eq("Example user")
-    end
+    it_behaves_like(
+      'a valid auth',
+      configuration='eap-tls-accept.conf',
+      logged_with={cert_name: "Example user"}
+    )
   end
 
   context 'with invalid eap-tls' do

--- a/acceptance_tests/spec/gov_wifi_healtcheck_spec.rb
+++ b/acceptance_tests/spec/gov_wifi_healtcheck_spec.rb
@@ -1,18 +1,17 @@
 require 'net/http'
-require 'sequel'
+require 'spec_helper.rb'
 
 describe 'GovWifi Healtcheck' do
-  let(:db) do
-    Sequel.connect(
-      adapter: 'mysql2',
-      host: ENV.fetch('DB_HOSTNAME'),
-      database: ENV.fetch('DB_NAME'),
-      user: ENV.fetch('DB_USER'),
-      password: ENV.fetch('DB_PASS')
+  before do
+    db[:userdetails].insert(
+      {
+        username: 'DSLPR',
+        contact: '+447766554430',
+        password: 'SharpRegainDetailed',
+        mobile: '+447766554430'
+      }
     )
   end
-
-  let(:frontend_container) { ENV.fetch('FRONTEND_CONTAINER') }
   let(:request) { Net::HTTP.new("#{frontend_container}", port=3000) }
 
   it 'gets a 200 from the healtcheck' do

--- a/acceptance_tests/spec/gov_wifi_spec.rb
+++ b/acceptance_tests/spec/gov_wifi_spec.rb
@@ -1,79 +1,13 @@
-require 'socket'
-require 'sequel'
+require 'spec_helper.rb'
 
 describe 'GovWifi' do
-  let(:db) do
-    Sequel.connect(
-      adapter: 'mysql2',
-      host: ENV.fetch('DB_HOSTNAME'),
-      database: ENV.fetch('DB_NAME'),
-      user: ENV.fetch('DB_USER'),
-      password: ENV.fetch('DB_PASS')
-    )
-  end
-
-  let(:frontend_container_ip) do
-    TCPSocket.gethostbyname(ENV.fetch('FRONTEND_CONTAINER')).last
-  end
-
-  let(:radius_key) { ENV.fetch('RADIUS_KEY') }
-
-  let(:eapol_test_command) do
-    `eapol_test -t5 -c ./spec/support/#{configuration} -a #{frontend_container_ip} -s #{radius_key}`
-  end
-
-  let(:result) { eapol_test_command.split("\n").last }
-
-  context 'Authorisation' do
-    before do
-      db[:userdetails].truncate
-
-      db[:userdetails].insert(
-        {
-          username: 'DSLPR',
-          contact: '+447766554430',
-          password: 'SharpRegainDetailed',
-          mobile: '+447766554430'
-        }
-      )
-    end
+  context 'with valid peap-mschapv2' do
     let(:configuration) { 'peap-mschapv2-accept.conf' }
-
-    it 'ACCEPT' do
-      expect(result).to match('SUCCESS')
-    end
-
-    context 'Logging' do
-      before do
-        db[:sessions].truncate
-      end
-
-      it 'logs the authentication' do
-        eapol_test_command
-        expect(db[:sessions].order(:id).last).to_not be_nil
-      end
-
-      it 'logs exactly one sessions' do
-        eapol_test_command
-        expect(db[:sessions].count).to eq(1)
-      end
-    end
+    it_behaves_like 'a valid auth'
   end
 
-  context 'Authorisation' do
+  context 'with invalid peap-mschapv2' do
     let(:configuration) { 'peap-mschapv2-reject.conf' }
-
-    it 'REJECT' do
-      expect(result).to eq('FAILURE')
-    end
-
-    context 'Radius shared secret' do
-      let(:configuration) { 'peap-mschapv2-accept.conf' }
-      let(:radius_key) { 'somerandomkey' }
-
-      it 'REJECT' do
-        expect(result).to eq('FAILURE')
-      end
-    end
+    it_behaves_like 'an invalid auth'
   end
 end

--- a/acceptance_tests/spec/gov_wifi_spec.rb
+++ b/acceptance_tests/spec/gov_wifi_spec.rb
@@ -2,12 +2,10 @@ require 'spec_helper.rb'
 
 describe 'GovWifi' do
   context 'with valid peap-mschapv2' do
-    let(:configuration) { 'peap-mschapv2-accept.conf' }
-    it_behaves_like 'a valid auth'
+    it_behaves_like 'a valid auth', configuration='peap-mschapv2-accept.conf'
   end
 
   context 'with invalid peap-mschapv2' do
-    let(:configuration) { 'peap-mschapv2-reject.conf' }
-    it_behaves_like 'an invalid auth'
+    it_behaves_like 'an invalid auth', configuration='peap-mschapv2-reject.conf'
   end
 end

--- a/acceptance_tests/spec/spec_helper.rb
+++ b/acceptance_tests/spec/spec_helper.rb
@@ -1,0 +1,38 @@
+require 'socket'
+require 'sequel'
+
+Dir["./spec/support/shared_examples/*.rb"].sort.each { |f| require f }
+
+
+module DBHelper
+  extend RSpec::SharedContext
+  let(:db) do
+    Sequel.connect(
+      adapter: 'mysql2',
+      host: ENV.fetch('DB_HOSTNAME'),
+      database: ENV.fetch('DB_NAME'),
+      user: ENV.fetch('DB_USER'),
+      password: ENV.fetch('DB_PASS')
+    )
+  end
+
+  before do
+    db[:userdetails].truncate
+    db[:sessions].truncate
+  end
+end
+
+module EnvHelper
+  extend RSpec::SharedContext
+  let(:frontend_container) { ENV.fetch('FRONTEND_CONTAINER') }
+  let(:frontend_container_ip) do
+    TCPSocket.gethostbyname(frontend_container).last
+  end
+
+  let(:radius_key) { ENV.fetch('RADIUS_KEY') }
+end
+
+RSpec.configure do |c|
+  c.include DBHelper
+  c.include EnvHelper
+end

--- a/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
+++ b/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
@@ -1,0 +1,73 @@
+
+shared_examples 'a success logger' do
+  # needs :db
+  # needs :eapol_test_command
+
+  before do
+    eapol_test_command
+  end
+
+  it 'logs the authentication' do
+    expect(db[:sessions].order(:id).last).to_not be_nil
+  end
+
+  it 'logs exactly one sessions' do
+    expect(db[:sessions].count).to eq(1)
+  end
+end
+
+shared_examples 'set authentication context' do
+  # needs :db
+  # needs :configuration
+  # needs :frontend_container_ip
+  # needs :radius_key
+
+  let(:eapol_test_command) do
+    `eapol_test -t5 -c ./spec/support/#{configuration} -a #{frontend_container_ip} -s #{radius_key}`
+  end
+  let(:result) { eapol_test_command.split("\n").last }
+
+  before do
+    db[:userdetails].insert(
+      {
+        username: 'DSLPR',
+        contact: '+447766554430',
+        password: 'SharpRegainDetailed',
+        mobile: '+447766554430'
+      }
+    )
+  end
+end
+
+shared_examples 'a valid auth' do
+  include_examples 'set authentication context'
+
+  it 'ACCEPT' do
+    expect(result).to match('SUCCESS')
+  end
+  it_behaves_like 'a success logger'
+
+  context 'with invalid radius secret' do
+    let(:radius_key) { 'somerandomkey' }
+
+    it 'REJECT' do
+      expect(result).to eq('FAILURE')
+    end
+  end
+end
+
+shared_examples 'an invalid auth' do
+  include_examples 'set authentication context'
+
+  it 'REJECT' do
+    expect(result).to eq('FAILURE')
+  end
+
+  context 'with invalid radius secret' do
+    let(:radius_key) { 'somerandomkey' }
+
+    it 'REJECT' do
+      expect(result).to eq('FAILURE')
+    end
+  end
+end

--- a/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
+++ b/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
@@ -16,7 +16,7 @@ shared_examples 'a success logger' do
   end
 end
 
-shared_examples 'set authentication context' do
+shared_examples 'set authentication context' do |configuration|
   # needs :db
   # needs :configuration
   # needs :frontend_container_ip
@@ -26,6 +26,7 @@ shared_examples 'set authentication context' do
     `eapol_test -t5 -c ./spec/support/#{configuration} -a #{frontend_container_ip} -s #{radius_key}`
   end
   let(:result) { eapol_test_command.split("\n").last }
+  let(:logged_with) { {} unless logged_with }
 
   before do
     db[:userdetails].insert(
@@ -39,8 +40,8 @@ shared_examples 'set authentication context' do
   end
 end
 
-shared_examples 'a valid auth' do
-  include_examples 'set authentication context'
+shared_examples 'a valid auth' do |configuration|
+  include_examples 'set authentication context', configuration
 
   it 'ACCEPT' do
     expect(result).to match('SUCCESS')
@@ -56,8 +57,8 @@ shared_examples 'a valid auth' do
   end
 end
 
-shared_examples 'an invalid auth' do
-  include_examples 'set authentication context'
+shared_examples 'an invalid auth' do |configuration|
+  include_examples 'set authentication context', configuration
 
   it 'REJECT' do
     expect(result).to eq('FAILURE')

--- a/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
+++ b/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
@@ -1,5 +1,5 @@
 
-shared_examples 'a success logger' do
+shared_examples 'a success logger' do |logged_with={}|
   # needs :db
   # needs :eapol_test_command
 
@@ -13,6 +13,12 @@ shared_examples 'a success logger' do
 
   it 'logs exactly one sessions' do
     expect(db[:sessions].count).to eq(1)
+  end
+
+  if !logged_with&.empty?
+    it 'logs with expected entries' do
+      expect(db[:sessions].first).to include logged_with
+    end
   end
 end
 
@@ -40,13 +46,13 @@ shared_examples 'set authentication context' do |configuration|
   end
 end
 
-shared_examples 'a valid auth' do |configuration|
+shared_examples 'a valid auth' do |configuration, logged_with={}|
   include_examples 'set authentication context', configuration
 
   it 'ACCEPT' do
     expect(result).to match('SUCCESS')
   end
-  it_behaves_like 'a success logger'
+  it_behaves_like 'a success logger', logged_with
 
   context 'with invalid radius secret' do
     let(:radius_key) { 'somerandomkey' }


### PR DESCRIPTION
**What**
This moves the boilerplate for radius tests into shared examples.
It also centralises common configurations, and introduces a DB helper to handle cleanups.

**Why**
There were inconsistencies in the tests due to having duplicated boilerplate.
There was also a bug in the healtcheck tests where it depended on another test populating the credentials in the db.

The current process now is:

**valid auth**
- receives a `SUCCESS` from eapol
- logs a single entry into the database
- (optional): has specific values added to the log database
- will reject with an invalid radius secret

**invalid auth**
- receives a `FAILURE` from eapol
- will reject an invalid radius secret