### PR TITLE
reduce the timeout to 2 seconds for eapol_test

### DIFF
--- a/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
+++ b/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
@@ -29,7 +29,7 @@ shared_examples 'set authentication context' do |configuration|
   # needs :radius_key
 
   let(:eapol_test_command) do
-    `eapol_test -t5 -c ./spec/support/#{configuration} -a #{frontend_container_ip} -s #{radius_key}`
+    `eapol_test -t2 -c ./spec/support/#{configuration} -a #{frontend_container_ip} -s #{radius_key}`
   end
   let(:result) { eapol_test_command.split("\n").last }
   let(:logged_with) { {} unless logged_with }


### PR DESCRIPTION
We have tests that deliberately hit the timeout, so reduce it to save a lot of time