### PR TITLE
only bind ports in development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,8 +39,6 @@ services:
       HEALTH_CHECK_PASSWORD: SharpRegainDetailed
       RADIUSD_PARAMS: "-X"
       CERT_STORE_URL: "http://govwifi-fake-s3:8080"
-    ports:
-      - 9090:80
 
   govwifi-authentication-api-local:
     build:


### PR DESCRIPTION
We only want to bind ports while in development, to avoid doing it for in jenkins.

This will allow us to run the tests in parallel