### PR TITLE
change to using mysql 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       test: "mysql --user=root --password=testpassword -e 'SELECT 1'"
 
   govwifi-user-details-db:
-    image: mysql:5.7
+    image: mysql:8.0
+    command: "--default-authentication-plugin=mysql_native_password"
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: govwifi_local


### PR DESCRIPTION
This matches our hosted environment.

We need to use mysql_native_password, as mariadb client doesn't ship with this yet