### PR TITLE
fix: upgrade to Bundler 2.x and pin the correct Ruby version

### DIFF
--- a/acceptance_tests/Gemfile.lock
+++ b/acceptance_tests/Gemfile.lock
@@ -27,7 +27,7 @@ DEPENDENCIES
   sequel (~> 5.22)
 
 RUBY VERSION
-   ruby 2.1.5p273
+   ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.4
+   2.1.0


### PR DESCRIPTION
For reasons I don't fully understand, our locked Ruby and Bundler
version where too old. There are a couple issues I found that might be
relevant:

https://github.com/docker-library/ruby/issues/259
https://github.com/docker-library/ruby/pull/255

Regardless, Bundler 2 is the default version on this Alpine image, so
this should unblock our pipeline.