### PR TITLE
Pin localstack version to 0.11.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       test: "mysql --user=root --password=testpassword -e 'SELECT 1'"
 
   govwifi-fake-s3:
-    image: localstack/localstack
+    image: localstack/localstack:0.11.4
     ports:
       - "4572:4572"
       - "8080:8080"


### PR DESCRIPTION
`localstack` introduces a breaking change in 0.11.5 which is causing the acceptance tests to fail. To confirm this is the root cause we are pinning the version instead of accepting the latest.