### PR TITLE
Update localstack configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       test: "mysql --user=root --password=testpassword -e 'SELECT 1'"
 
   govwifi-fake-s3:
-    image: localstack/localstack:0.11.4
+    image: localstack/localstack
     ports:
       - "4572:4572"
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     image: localstack/localstack
     ports:
       - "4566:4566"
-      - "8080:8080"
     environment:
       - SERVICES=s3
       - DOCKER_HOST=unix:///var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   govwifi-fake-s3:
     image: localstack/localstack
     ports:
-      - "4572:4572"
+      - "4566:4566"
       - "8080:8080"
     environment:
       - SERVICES=s3
@@ -43,7 +43,7 @@ services:
     environment:
       AUTHORISATION_API_BASE_URL: "http://govwifi-authentication-api-local:8080"
       LOGGING_API_BASE_URL: "http://govwifi-logging-api-local:8080"
-      RADIUS_CONFIG_WHITELIST_URL: "http://govwifi-fake-s3:8080/clients.conf"
+      RADIUS_CONFIG_WHITELIST_URL: "http://govwifi-fake-s3:4566/clients.conf"
       HEALTH_CHECK_RADIUS_KEY: RrPTmh8s9NZFenAFx2kG
       HEALTH_CHECK_SSID: GovWifi
       HEALTH_CHECK_IDENTITY: DSLPR
@@ -64,7 +64,7 @@ services:
       AWS_SECRET_ACCESS_KEY: testsecret
       WHITELIST_BUCKET: s3://whitelist-bucket
       CERT_STORE_BUCKET: s3://certs-bucket
-      ENDPOINT_URL: "http://govwifi-fake-s3:4572"
+      ENDPOINT_URL: "http://govwifi-fake-s3:4566"
     volumes:
       - raddb-certs:/etc/raddb/certs
 


### PR DESCRIPTION
* Unpin localstack version
* We proved pinning to an older version of localstack fixed the FE acceptance tests, we're now going to follow the updates recommended by localstack in their [Changelog](https://github.com/localstack/localstack/blob/master/CHANGELOG.md) and return to pulling the latest image.
* Use port 4566 for localstack fake S3 configuration.
* Remove unused port binding.