### PR TITLE
Make it so each concourse pipeline can only run once at a time

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -105,6 +105,7 @@ jobs:
 
   - name: test
     interruptible: true
+    max_in_flight: 1
     plan:
       - in_parallel:
         - get: src


### PR DESCRIPTION
**WHAT**

Make it so each concourse pipeline can only run once at a time

**WHY**

Or we can get clogged up with lots of semi failed builds running at once
e.g.
![image](https://user-images.githubusercontent.com/77979241/118144508-71f9d780-b404-11eb-848f-aa16eca23d13.png)
