### PR TITLE
Use the builtin set_pipeline in ci/pipelines/pr.yml

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -13,11 +13,6 @@ resource_types:
     repository: teliaoss/github-pr-resource
 
 resources:
-  - name: tech-ops
-    type: git
-    source:
-      uri: https://github.com/alphagov/tech-ops.git
-
   - name: govwifi-acceptance-tests
     type: git
     source:
@@ -89,19 +84,10 @@ jobs:
   - name: self-update
     serial: true
     plan:
-    - get: tech-ops
-      params:
-        submodules: none
     - get: govwifi-acceptance-tests
       trigger: true
-    - task: set-pipelines
-      file: tech-ops/ci/tasks/self-updating-pipeline.yaml
-      input_mapping: {repository: govwifi-acceptance-tests}
-      params:
-        CONCOURSE_TEAM: govwifi
-        CONCOURSE_PASSWORD: ((readonly_local_user_password))
-        PIPELINE_PATH: ci/pipelines/pr.yml
-        PIPELINE_NAME: acceptance-tests-pr
+    - set_pipeline: acceptance-tests-pr
+      file: govwifi-acceptance-tests/ci/pipelines/pr.yml
 
   - name: test
     interruptible: true


### PR DESCRIPTION
### What
Use the builtin set_pipeline in ci/pipelines/pr.yml

### Why
This avoids using the deprecated tech-ops task, and works better with
the GovWifi Concourse.


Link to Trello card: https://trello.com/c/V2kD9sH0/1730-concourse-migration-acceptance-tests-pr-pipeline