### PR TITLE
Remove wait_for_mysql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ build: setup
 
 	docker-compose up -d govwifi-sessions-db govwifi-user-details-db govwifi-fake-s3
 	docker-compose build
-	./scripts/wait_for_mysql govwifi-sessions-db & ./scripts/wait_for_mysql govwifi-user-details-db & wait
 	cat testdatabase/sessions.sql | docker-compose exec -T govwifi-sessions-db mysql -uroot -hgovwifi-sessions-db -ptestpassword govwifi_local
 	cat testdatabase/user_details.sql | docker-compose exec -T govwifi-user-details-db mysql -uroot -hgovwifi-user-details-db -ptestpassword govwifi_local
 	docker-compose up govwifi-frontend-raddb-local

--- a/scripts/wait_for_mysql
+++ b/scripts/wait_for_mysql
@@ -1,7 +1,0 @@
-#!/bin/bash
-db_name="${1}"
-until docker-compose exec -T "${db_name}" mysql -h${db_name} -uroot -ptestpassword -e 'SELECT 1' &> /dev/null
-do
-  printf "."
-  sleep 1
-done


### PR DESCRIPTION
### What
Remove wait_for_mysql

### Why
The docker compose configuration already looks to be using a
healthcheck, which is a neater way of doing the same thing.


Link to Trello card: https://trello.com/c/5EB2Bm1i/1963-upgrade-apps-to-ruby-3