### PR TITLE
Add tests for TLS versions

### DIFF
--- a/acceptance_tests/spec/gov_wifi_certs_spec.rb
+++ b/acceptance_tests/spec/gov_wifi_certs_spec.rb
@@ -7,9 +7,22 @@ describe 'GovWifi Certificate Authentication' do
       configuration='eap-tls-accept.conf',
       logged_with={cert_name: "Example user"}
     )
+
+    it_behaves_like 'using TLS version 1.2', configuration='eap-tls-accept.conf'
+  end
+
+  context 'With valid eap-tls and TLS 1.0' do
+    it_behaves_like(
+      'a valid auth',
+      configuration='eap-tls-accept-tls1.0.conf',
+      logged_with={cert_name: "Example user"}
+    )
+
+    it_behaves_like 'using TLS version 1.0', configuration='eap-tls-accept-tls1.0.conf'
   end
 
   context 'with invalid eap-tls' do
     it_behaves_like 'an invalid auth', configuration='eap-tls-reject.conf'
+    it_behaves_like 'using TLS version 1.2', configuration='eap-tls-reject.conf'
   end
 end

--- a/acceptance_tests/spec/gov_wifi_spec.rb
+++ b/acceptance_tests/spec/gov_wifi_spec.rb
@@ -3,9 +3,16 @@ require 'spec_helper.rb'
 describe 'GovWifi' do
   context 'with valid peap-mschapv2' do
     it_behaves_like 'a valid auth', configuration='peap-mschapv2-accept.conf'
+    it_behaves_like 'using TLS version 1.2', configuration='peap-mschapv2-accept.conf'
   end
 
   context 'with invalid peap-mschapv2' do
     it_behaves_like 'an invalid auth', configuration='peap-mschapv2-reject.conf'
+    it_behaves_like 'using TLS version 1.2', configuration='peap-mschapv2-reject.conf'
+  end
+
+  context 'with valid peap-mschapv2 and TLS1.0' do
+    it_behaves_like 'a valid auth', configuration='peap-mschapv2-accept-tls1.0.conf'
+    it_behaves_like 'using TLS version 1.0', configuration='peap-mschapv2-accept-tls1.0.conf'
   end
 end

--- a/acceptance_tests/spec/support/eap-tls-accept-tls1.0.conf
+++ b/acceptance_tests/spec/support/eap-tls-accept-tls1.0.conf
@@ -1,0 +1,12 @@
+network={
+        ssid="GovWifi"
+        key_mgmt=WPA-EAP
+        eap=TLS
+        identity="whatever"
+        ca_cert="/usr/src/app/certs/ca.pem"
+        client_cert="/usr/src/app/certs/client.pem"
+        private_key="/usr/src/app/certs/client.key"
+        private_key_passwd="whatever"
+        eapol_flags=3
+        phase1="tls_disable_tlsv1_0=0 tls_disable_tlsv1_1=1 tls_disable_tlsv1_2=1 tls_disable_tlsv1_3=1"
+}

--- a/acceptance_tests/spec/support/peap-mschapv2-accept-tls1.0.conf
+++ b/acceptance_tests/spec/support/peap-mschapv2-accept-tls1.0.conf
@@ -1,0 +1,10 @@
+network={
+        ssid="GovWifi"
+        key_mgmt=WPA-EAP
+        eap=PEAP
+        identity="DSLPR"
+        anonymous_identity="anonymous"
+        password="SharpRegainDetailed"
+        phase1="tls_disable_tlsv1_0=0 tls_disable_tlsv1_1=1 tls_disable_tlsv1_2=1 tls_disable_tlsv1_3=1"
+        phase2="autheap=MSCHAPV2"
+}

--- a/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
+++ b/acceptance_tests/spec/support/shared_examples/eapol_auth.rb
@@ -46,6 +46,22 @@ shared_examples 'set authentication context' do |configuration|
   end
 end
 
+shared_examples 'using TLS version 1.0' do |configuration|
+  include_examples 'set authentication context', configuration
+
+  it 'uses TLS version 1.0' do
+    expect(eapol_test_command).to include('SSL: Using TLS version TLSv1')
+  end
+end
+
+shared_examples 'using TLS version 1.2' do |configuration|
+  include_examples 'set authentication context', configuration
+
+  it 'uses TLS version 1.2' do
+    expect(eapol_test_command).to include('SSL: Using TLS version TLSv1.2')
+  end
+end
+
 shared_examples 'a valid auth' do |configuration, logged_with={}|
   include_examples 'set authentication context', configuration
 


### PR DESCRIPTION
Add tests to check the TLS versions used and a test that Radius
accepts TLS version 1.0

### Why
TLS version 1.0 should at this time be accepted and there should be
tests to verify this

Trello: https://trello.com/c/7Y8D6z4x/1340-test-different-versions-of-tls-in-our-acceptance-tests
