### PR TITLE
Set the environment variable for the default region

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       govwifi-fake-s3:
         condition: service_healthy
     environment:
-      DEFAULT_REGION: eu-west-1
+      AWS_DEFAULT_REGION: eu-west-1
       AWS_ACCESS_KEY_ID: testkey
       AWS_SECRET_ACCESS_KEY: testsecret
       ALLOWLIST_BUCKET: s3://allowlist-bucket


### PR DESCRIPTION
The aws-cli 's3 cp' command requires the reqion to be set. This can be done with an enivronment variable, which should be prefixed with 'AWS'
