### PR TITLE
updating build args for logging-api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     build:
       context: .logging-api
       args:
-        BUNDLE_INSTALL_CMD: bundle install --without test --no-cache --jobs 20 --retry 5
+        BUNDLE_INSTALL_CMD: bundle install --without test, vscodedev --no-cache --jobs 1 --retry 5
     environment:
       DB_HOSTNAME: govwifi-sessions-db
       DB_USER: root


### PR DESCRIPTION
### What
Change the buid args to remove the vscodedev group from container

### Why
Changes to the actual govwifi-logging-api have caused a difference to appear.

Link to Trello card (if applicable): 
