### PR TITLE
Fix acceptance test failures caused by HostAuthorization in Sinatra 4.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 setup: .frontend .authentication-api .logging-api
 
 build: setup
-	docker-compose down
-	docker-compose build --progress plain
-	docker-compose up govwifi-frontend-raddb-local
+	docker compose down
+	docker compose build --progress plain
+	docker compose up govwifi-frontend-raddb-local
 
 test: build
-	docker-compose run --rm govwifi-test
+	docker compose run --rm govwifi-test
 
 .frontend:
 	git clone https://github.com/alphagov/govwifi-frontend.git .frontend
@@ -18,7 +18,7 @@ test: build
 	git clone https://github.com/alphagov/govwifi-logging-api.git .logging-api
 
 destroy: .frontend .authentication-api .logging-api
-	docker-compose down --volumes
+	docker compose down --volumes
 
 clean:
 	rm -rf .frontend .logging-api .authentication-api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       args:
         BUNDLE_INSTALL_CMD: bundle install --without test --no-cache --jobs 8
     environment:
+      APP_ENV: production
       DB_HOSTNAME: govwifi-user-details-db
       DB_USER: root
       DB_PASS: testpassword
@@ -102,6 +103,7 @@ services:
       args:
         BUNDLE_INSTALL_CMD: bundle install --without test, vscodedev --no-cache --jobs 1 --retry 5
     environment:
+      APP_ENV: production
       DB_HOSTNAME: govwifi-sessions-db
       DB_USER: root
       DB_PASS: testpassword


### PR DESCRIPTION
The acceptance tests failed because Sinatra 4.1.0 introduced `HostAuthorization` https://github.com/sinatra/sinatra/pull/2053, which rejects connections from remote hosts by default unless explicitly allowed. This behavior affects environments where the app is accessed from remote addresses during tests.

Setting `APP_ENV` to `production` fixes that, allowing the tests to pass without further configuration. Updated the environment setup to include this fix.


Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-2053