### PR TITLE
Fix localstack s3 not starting issue for now. 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - DEFAULT_REGION=eu-west-1
       - AWS_ACCESS_KEY_ID=testkey
       - AWS_SECRET_ACCESS_KEY=testsecret
+      - LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1
     healthcheck:
       test: "[ $$(AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake aws --endpoint-url=http://localhost:4566 s3 ls certs-bucket | wc -l) -gt 2 ]"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
   govwifi-fake-s3:
     # See https://blog.localstack.cloud/2026-upcoming-pricing-changes/
     # Pinning to a specific version of localstack that still has the free tier.
+    # There will be no more fixes and security updates to this version. We will
+    # need to migrate to an alternative solution or pay for a license.
     image: localstack/localstack:community-archive
     ports:
       - "4566:4566"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,9 @@ services:
       test: "mysql --user=root --password=testpassword -e 'SELECT 1'"
 
   govwifi-fake-s3:
-    image: localstack/localstack
+    # See https://blog.localstack.cloud/2026-upcoming-pricing-changes/
+    # Pinning to a specific version of localstack that still has the free tier.
+    image: localstack/localstack:community-archive
     ports:
       - "4566:4566"
     environment:
@@ -38,7 +40,6 @@ services:
       - DEFAULT_REGION=eu-west-1
       - AWS_ACCESS_KEY_ID=testkey
       - AWS_SECRET_ACCESS_KEY=testsecret
-      - LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1
     healthcheck:
       test: "[ $$(AWS_ACCESS_KEY_ID=fake AWS_SECRET_ACCESS_KEY=fake aws --endpoint-url=http://localhost:4566 s3 ls certs-bucket | wc -l) -gt 2 ]"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,10 @@ services:
       test: "mysql --user=root --password=testpassword -e 'SELECT 1'"
 
   govwifi-fake-s3:
-    # See https://blog.localstack.cloud/2026-upcoming-pricing-changes/
-    # Pinning to a specific version of localstack that still has the free tier.
+    # See https://blog.localstack.cloud/2026-upcoming-pricing-changes/ if you
+    # want to keep using localstack/localstack:latest
+    #
+    # Pinning to this version of localstack as it still has the free tier.
     # There will be no more fixes and security updates to this version. We will
     # need to migrate to an alternative solution or pay for a license.
     image: localstack/localstack:community-archive


### PR DESCRIPTION
### What
- Localstack has switched licensing model, so will become paid for commercial use. 
- We need to look at options to resolve this long term

### Why
- Fix localstack s3 not starting issue for now unblocking CI/CD pipelines
- It should work until 6 April 2023. 
