### PR TITLE
Upgrade Admin DB Version To MYSQL 8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,8 +245,7 @@ services:
   govwifi-admin-db:
     ports:
       - "33306:3306"
-    image: mysql:8.0
-    command: "--default-authentication-plugin=mysql_native_password"
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: admin_govwifi


### PR DESCRIPTION
### What
Upgrade Admin DB Version To MYSQL 8.4

### Why
This is to match the version we are now running in production. It relates to: GovWifi/govwifi-terraform/pull/1016

Remove "--==default-authentication-plugin==" as it is no longer supported in MYSQL 8.4 and causes an error, when testing locally

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-2793