### PR TITLE
Upgrade Sessions DB Version To MYSQL 8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   govwifi-sessions-db:
     ports:
       - "13306:3306"
-    image: mysql:8.0
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: govwifi_local


### PR DESCRIPTION
### What
Upgrade Sessions DB Version To MYSQL 8.4

### Why
This is to match the version we are now running in production. It relates to: GovWifi/govwifi-terraform/pull/1020

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-2813