### PR TITLE
Upgrade User DB Version To MYSQL 8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,7 @@ services:
     # check with.
     ports:
       - "23306:3306"
-    image: mysql:8.0
-    command: "--default-authentication-plugin=mysql_native_password"
+    image: mysql:8.4
     environment:
       MYSQL_ROOT_PASSWORD: testpassword
       MYSQL_DATABASE: govwifi_local


### PR DESCRIPTION
### What
Upgrade User DB Version To MYSQL 8.4
Remove "--==default-authentication-plugin==" as it is no longer supported in MYSQL 8.4 and causes an error, when testing locally

### Why
This is to match the version we are now running in production. It relates to: GovWifi/govwifi-terraform/pull/1022

### Link to JIRA card (if applicable): 
https://technologyprogramme.atlassian.net/browse/GW-2733