### PR TITLE
 Fix gitignore: changed directory patterns from /**/* to simple names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
-.authentication-api/**/*
-.frontend/**/*
-.user-signup-api/**/*
-.logging-api/**/*
-.backend/**/*
-.admin/**/*
+.authentication-api/
+.frontend/
+.user-signup-api/
+.logging-api/
+.backend/
+.admin/
 acceptance_tests/.certs
 fake-s3/.certs
 fake-s3/*.pem


### PR DESCRIPTION
### What
                                                                                                                                                                                                                                                                               
Fixed gitignore patterns to properly exclude directories that were previously untracked. Changed from directory/**/* syntax (which only ignores files within a directory but not the directory itself) to proper directory-level ignores. This ensures 5 untracked directories are 
now ignored: .admin/, .authentication-api/, .frontend/, .logging-api/, and .user-signup-api/.
                                                                                                                                                                                          
### Why
                                                                                                                                                                                                                                                                               
The /**/* pattern in gitignore only matches files AND SUBDIRECTORIES inside a parent directory, but does NOT ignore the parent directory itself. This caused all directories at that level to show as new/untracked (??). The correct way to ignore entire directories is to specify 
just the directory name (e.g., .admin/ not .admin/**/*).