### PR TITLE
Fix ruby updater action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,3 @@ updates:
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: ruby
-    versions:
-    - 3.0.0.pre.alpine

--- a/.github/workflows/ruby_updater.yml
+++ b/.github/workflows/ruby_updater.yml
@@ -3,15 +3,17 @@ name: Upgrade Ruby in multiple environments
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 15 * 0" # Runs monthly (in the middle to avoid any date clashes)
+    - cron: "0 2 15 * *" # Runs monthly (in the middle to avoid any date clashes)
 
-permissions:
-  contents: write
-  pull-requests: write
+env:
+  MAIN_BRANCH: 'master'
+  MAJOR_VERSION: '3'
 
 jobs:
   check-ruby-setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       TARGET_RUBY_VERSION: ${{ steps.check-ruby.outputs.TARGET_RUBY_VERSION }}
       NEW_RUBY: ${{ steps.check-ruby.outputs.NEW_RUBY }}
@@ -20,36 +22,48 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v4
-
+      uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    ## This step will check the current Ruby version against the latest available version for the specified major version. It will set outputs TARGET_RUBY_VERSION, NEW_RUBY, and RUBY_PATHS.
     - name: Check Ruby Version
       id: check-ruby
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-version-check@main
+      with:
+        major-version: ${{ env.MAJOR_VERSION }}
+
 
     - name: Setup github branch for Ruby Updates
       id: setup-branch
-      if: ${{ steps.check-ruby.outputs.NEW_RUBY }} == 'true'
+      ## Only run if the Ruby Version has changed.
+      if: ${{ steps.check-ruby.outputs.NEW_RUBY == 'true' }}
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-setup-branch@main
       env:
         TARGET_RUBY_VERSION: ${{ steps.check-ruby.outputs.TARGET_RUBY_VERSION }}
 
   upgrade-ruby:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
     needs: [check-ruby-setup]
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
-    -  name: Update Ruby Version
-       env:
+    - name: Update Ruby Version
+      env:
          TARGET_RUBY_VERSION: ${{ needs.check-ruby-setup.outputs.TARGET_RUBY_VERSION }}
          COMMIT_BRANCH: ${{ needs.check-ruby-setup.outputs.COMMIT_BRANCH }}
          NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
          RUBY_PATHS: ${{ needs.check-ruby-setup.outputs.RUBY_PATHS}}
-       ## Only update if the Ruby Version has changed.
-       if: ${{ env.NEW_RUBY }} == 'true'
-       uses: govwifi/shared-actions-workflows/.github/actions/ruby-updater-multi-env@main
+      ## Only update if the Ruby Version has changed.
+      if: ${{ env.NEW_RUBY == 'true' }}
+      uses: govwifi/shared-actions-workflows/.github/actions/ruby-updater-multi-env@main
 
     - name: Commit and Raise PR
       env:
@@ -58,7 +72,7 @@ jobs:
          NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-commit-changes@main
       ## Only update if the Ruby Version has changed.
-      if: ${{ env.NEW_RUBY }} == 'true'
+      if: ${{ env.NEW_RUBY == 'true' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        main-branch: master
+        main-branch: ${{ env.MAIN_BRANCH }}


### PR DESCRIPTION
### What
fix permissions and syntax of the workflow
Remove Ruby from dependabot check

### Why
Improve code and tighten security and Ruby updating now handled by GHA

### Link to JIRA card (if applicable): 
n/a